### PR TITLE
Link colours

### DIFF
--- a/Memento/Memento.body.php
+++ b/Memento/Memento.body.php
@@ -101,7 +101,7 @@ class Memento {
 		// $mementoResource is only set if we are on an actual page
 		// as opposed to diff pages, edit pages, etc.
 		if ( $this->mementoResource ) {
-			$this->mementoResource->fixTemplate( $title, $parser, &$skip, &$id );
+			$this->mementoResource->fixTemplate( $title, $parser, $skip, $id );
 		}
 
 		return true;
@@ -120,7 +120,7 @@ class Memento {
 		$linkcolour_ids, &$colours ) {
 
 		if ( $this->mementoResource ) {
-			$this->mementoResource->fixLinkColours( $linkcolour_ids, &$colours /*, $parser*/ );
+			$this->mementoResource->fixLinkColours( $linkcolour_ids, $colours /*, $parser*/ );
 		}
 
 		return true;

--- a/Memento/Memento.body.php
+++ b/Memento/Memento.body.php
@@ -101,7 +101,26 @@ class Memento {
 		// $mementoResource is only set if we are on an actual page
 		// as opposed to diff pages, edit pages, etc.
 		if ( $this->mementoResource ) {
-			$this->mementoResource->fixTemplate( $title, $parser, $id );
+			$this->mementoResource->fixTemplate( $title, $parser, &$skip, &$id );
+		}
+
+		return true;
+	}
+	
+	/**
+	 * The GetLinkColours hook, used here to verify the colour of the
+	 * links at the Memento date
+	 *
+	 * @param array $linkcolour_ids Titles (DB keys) of all links to be checked
+	 * @param array $colours Corresponding colours of the links ('', 'new', 'mw-redirect', 'stub')
+	 *
+	 * @return boolean indicating success to the caller
+	 */
+	public function onGetLinkColours(
+		$linkcolour_ids, &$colours ) {
+
+		if ( $this->mementoResource ) {
+			$this->mementoResource->fixLinkColours( $linkcolour_ids, &$colours /*, $parser*/ );
 		}
 
 		return true;

--- a/Memento/Memento.php
+++ b/Memento/Memento.php
@@ -95,3 +95,4 @@ $wgMemento = new Memento();
 $wgHooks['ArticleViewHeader'][] = $wgMemento;
 $wgHooks['BeforeParserFetchTemplateAndtitle'][] = $wgMemento;
 $wgHooks['ImageBeforeProduceHTML'][] = $wgMemento;
+$wgHooks['GetLinkColours'][] = $wgMemento;

--- a/Memento/MementoResource.php
+++ b/Memento/MementoResource.php
@@ -553,7 +553,7 @@ abstract class MementoResource {
 	 *
 	 * @return array containing the text, finalTitle, and deps
 	 */
-	public function fixLinkColours( $titles, $colours /*, Parser $parser*/ ) {
+	public function fixLinkColours( $titles, &$colours /*, Parser $parser*/ ) {
 
 		//$parser->disableCache();
 

--- a/Memento/MementoResource.php
+++ b/Memento/MementoResource.php
@@ -494,7 +494,7 @@ abstract class MementoResource {
 	 *
 	 * @return array containing the text, finalTitle, and deps
 	 */
-	public function fixTemplate( Title $title, Parser $parser, &$id ) {
+	public function fixTemplate( Title $title, Parser $parser, &$skip, &$id ) {
 
 		$parser->disableCache();
 
@@ -534,11 +534,51 @@ abstract class MementoResource {
 			} else {
 				// if we get something prior to the first memento, just
 				// go with the first one
-				$id = $firstRev->getId();
+				$skip = true;
 			}
 		}
 	}
 
+	/**
+	 * fixLinkColour
+	 *
+	 * This code ensures that the links have the colour they had at the
+	 * Memento time.
+	 *
+	 * @fixme make this compatible with parser cache
+	 * @fixme manage the case where an article was created then deleted, and the datetime is after the deletion
+	 * @fixme check if the link is a redirect or a stub (small article lesser than a threshold)
+	 * @param array $titles
+	 * @param array $colours
+	 *
+	 * @return array containing the text, finalTitle, and deps
+	 */
+	public function fixLinkColours( $titles, $colours /*, Parser $parser*/ ) {
+
+		//$parser->disableCache();
+
+		$request = $this->article->getContext()->getRequest();
+
+		if ( $request->getHeader( 'ACCEPT-DATETIME' ) ) {
+
+			$requestDatetime = $request->getHeader( 'ACCEPT-DATETIME' );
+
+			$mwMementoTimestamp = $this->parseRequestDateTime(
+				$requestDatetime );
+
+			foreach ( $titles as $id => $s ) {
+
+				$title = Title::newFromID( $id );
+				$pdbk = $title->getPrefixedDBkey();
+				$firstRev = $title->getFirstRevision();
+				if ( is_null($firstRev) || $firstRev->getTimestamp() > $mwMementoTimestamp ) {
+					$colours[$pdbk] = 'new';
+				} else {
+					$colours[$pdbk] = '';
+				}
+			}
+		}
+	}
 
 	/**
 	 * alterHeaders


### PR DESCRIPTION
This adds the feature about the colour of the links – red or blue – at the time of the Memento.

It has been quickly tested on one example (so more testing is probably needed), and more work is needed for the details (see @fixme: green and blue italics colours, and deleted-then-recreated links, and check the parser cache status about the link colours).

I will understand if you prefer not to merge now, to check the parser cache status and wait more testing. In any case, I will try to continue to work on this feature. As a side note, I plan to incoporate the work I did on my extension BackwardsTimeTravel into Memento https://www.mediawiki.org/wiki/Extension:BackwardsTimeTravel#Deprecation.
