### PR TITLE
typo fixes and tweaks for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Memento framework allows you to see versions of articles as they existed at 
 
 This package contains the source code, build scripts, and tests for the Memento MediaWiki Extension.
 
-This file also contains installation information, but more comprehensive information about the extension is at:  http://www.mediawiki.org/wiki/Extension:Memento
+This file also contains installation information, but more comprehensive information about the extension is at:  https://www.mediawiki.org/wiki/Extension:Memento
 
 Note: the released version of this extension does not contain this file, so the target audience for this file is those who wish to build/maintain the source code.
 
@@ -23,28 +23,28 @@ Note: the released version of this extension does not contain this file, so the 
 
 # Installation
 
-To install this package within Mediawiki perform the following:
-* copy the Memento directory into the extensions directory of your Mediawiki installation
-* add the following to the LocalSettings.php file in your Mediawiki installation:
+To install this package within MediaWiki perform the following:
+* copy the Memento directory into the extensions directory of your MediaWiki installation
+* add the following to the LocalSettings.php file in your MediaWiki installation:
 ```
-    require_once("$IP/extensions/Memento/Memento.php");
+    require_once "$IP/extensions/Memento/Memento.php";
 ```
 
 # Configuration
 
 This extension has sensible defaults, but also allows the following settings to be added to LocalSettings.php in order to alter its behavior:
 
-* $wgMementoTimemapNumberOfMementos - (default is 500) allows the user to alter the number of Mementos included in a TimeMap served up by this extension (default is 500)
+* `$wgMementoTimemapNumberOfMementos` - (default is 500) allows the user to alter the number of Mementos included in a TimeMap served up by this extension (default is 500)
 
-* $wgMementoIncludeNamespaces - is an array of Mediawiki Namespace IDs (e.g. the integer values for Talk, Template, etc.) to include for Mementofication, default is an array containing just 0 (Main); the list of Mediawiki Namespace IDs is at http://www.mediawiki.org/wiki/Manual:Namespace
+* `$wgMementoIncludeNamespaces` - is an array of MediaWiki Namespace IDs (e.g. the integer values for Talk, Template, etc.) to include for Mementofication, default is an array containing just 0 (Main); the list of MediaWiki Namespace IDs is at https://www.mediawiki.org/wiki/Manual:Namespace
 
-* $wgMementoTimeNegotiationForThumbnails - EXPERIMENTAL: MediaWiki, by default, does not preserve temporal coherence for its oldid pages.  In other words, and oldid (URI-M) page will not contain the version of the image that existed when that page was created.  See http://arxiv.org/pdf/1402.0928.pdf for more information on this problem in web archives.
+* `$wgMementoTimeNegotiationForThumbnails` - EXPERIMENTAL: MediaWiki, by default, does not preserve temporal coherence for its oldid pages.  In other words, and oldid (URI-M) page will not contain the version of the image that existed when that page was created.  See http://arxiv.org/pdf/1402.0928.pdf for more information on this problem in web archives.
     * false - (default) do not attempt to match the old version of the image to the requested oldid page
     * true - attempt to match the old version of the image to the requested oldid page
 
 # Packaging
 
-To package the Memento Mediawiki Extension, type the following 
+To package the Memento MediaWiki Extension, type the following 
 from this directory:
 
     make package
@@ -53,14 +53,14 @@ This serves to run everything needed to verify the code and package the zip for 
 
 # Automated Deployment for Testing
 
-To deploy the Memento Mediawiki Extension locally for testing, one must first indicate to the shell where Mediawiki is installed, then run the appropriate make target.
+To deploy the Memento MediaWiki Extension locally for testing, one must first indicate to the shell where MediaWiki is installed, then run the appropriate make target.
 
 ```
-    export MWDIR=<where your Mediawiki is installed>
+    export MWDIR=<where your MediaWiki is installed>
     make deploy
 ```
 
-To remove the software from a Mediawiki instance, type:
+To remove the software from a MediaWiki instance, type:
 
 ```
     make undeploy
@@ -72,13 +72,13 @@ Once the code is deployed, the integration tests can be run.
 
 Running the integration tests requires phpunit.
 
-You will need to change the test data inside tests/integration/data to reflect your Mediawiki installation URIs and appropriate expected data.  Seeing as Mementos vary from site to site, it was decided not to come up with a "one size fits all" integration test set.  Example test data exists for our demo site in the 'demo-wiki' directory.
+You will need to change the test data inside tests/integration/data to reflect your MediaWiki installation URIs and appropriate expected data.  Seeing as Mementos vary from site to site, it was decided not to come up with a "one size fits all" integration test set.  Example test data exists for our demo site in the 'demo-wiki' directory.
 
 **For more information on the integration tests and the test data format, consult the tests/integration/integration-test-description.html and tests/integration/how-to-read-output.txt files.  Detailed test output is generated in the build/test-output directory once the integration tests are run.**
 
 Before running the tests you will need to set the following environment variables:
 * TESTDATADIR - the data directory containing the datasets for your test run
-* TESTUSERNAME - the username for logging into your mediawiki instance
+* TESTUSERNAME - the username for logging into your MediaWiki instance
 * TESTPASSWORD - the password that goes with TESTUSERNAME
 
 Because of all of the possible combinations of configuration options, the following Make targets are intended to test the following capabilities:
@@ -99,13 +99,13 @@ Of course, the fastest development process is:
 
 Running the code compliance requires phpcs.
 
-This git repository uses and external repository for coding convention rules, so we can update the coding convention rules at any time.  The git command for performing the initial import is:
+This git repository uses an external repository for coding convention rules, so we can update the coding convention rules at any time.  The git command for performing the initial import is:
 
 ```
     git submodule update --init
 ```
 
-To see if the code complies with Mediawiki's coding conventions, run:
+To see if the code complies with MediaWiki's coding conventions, run:
 
 ```
     make verify


### PR DESCRIPTION
- write MediaWiki in CamelCase
- use HTTPS for www.mediawiki.org
- variable names as code elements
